### PR TITLE
Implement time step discretization for Karras samplers

### DIFF
--- a/k_diffusion/utils.py
+++ b/k_diffusion/utils.py
@@ -7,8 +7,9 @@ import urllib
 import warnings
 
 import torch
-from torch import optim
+from torch import optim, Tensor
 from torchvision.transforms import functional as TF
+from typing import Union
 
 
 def from_pil_image(x):
@@ -249,3 +250,8 @@ def rand_log_uniform(shape, min_value, max_value, device='cpu', dtype=torch.floa
     min_value = math.log(min_value)
     max_value = math.log(max_value)
     return (torch.rand(shape, device=device, dtype=dtype) * (max_value - min_value) + min_value).exp()
+
+
+def quantize(quanta: Tensor, candidate: Union[int, float, Tensor]) -> Tensor:
+    """Rounds `candidate` to the nearest element in `quanta`"""
+    return quanta[torch.argmin((quanta-candidate).abs(), dim=0)]


### PR DESCRIPTION
Improves support for diffusion models with discrete time-steps (such as Stable Diffusion's DDIM).  
I have some questions though, so this may need some iterating.

The user would invoke like so:

```python
from k_diffusion.sampling import sample_heun, get_sigmas_karras, make_quantizer

sigmas = get_sigmas_karras(
    n=opt.steps,
    # 0.0292
    sigma_min=model_k_wrapped.sigmas[0].item(),
    # 14.6146
    sigma_max=model_k_wrapped.sigmas[-1].item(),
    rho=7.,
    device=device,
    # zero would be smaller than sigma_min
    concat_zero=False
)

samples = sample_heun(
    model_k_config,
    x,
    sigmas,
    extra_args=extra_args,
    decorate_sigma_hat=make_quantizer(model_k_wrapped.sigmas))
```

Implements the change to "Algorithm 2, line 5" described in the Elucidating paper [arXiv:2206.00364](https://arxiv.org/abs/2206.00364) section C.3.4 "iDDPM practical considerations" practical challenge 3.  
In other words we round sigmas to the nearest sigma supported by the DDIM.  
For your convenience, here's the sigmas supported by Stable Diffusion DDIM:  
https://gist.github.com/Birch-san/6cd1574e51871a5e2b88d59f0f3d4fd3

<img width="693" alt="image" src="https://user-images.githubusercontent.com/6141784/187564515-938a035a-184f-4f88-ab52-5a1eeba8bdd0.png">

<img width="683" alt="image" src="https://user-images.githubusercontent.com/6141784/187564567-16a7a234-6f94-484a-bb74-fee28a098be3.png">

You may be wondering "okay, rounding sigma_hat solves challenge 3, but what about challenge 2".  
There's an argument that solving challenge 3, solves challenge 2 for some situations.  
When `gamma == 0`, rounding sigma_hat is equivalent to rounding sigma (which is what challenge 2 requires you to do for any outputs of `get_sigmas_karras()`).  
Problem here is the final sigma we'll receive, 0. we probably don't want to apply the same rounding rules to that… especially because we have a special-case predicated on 0. should that be predicated on uargmin instead, or perhaps on "have we reached the final sigma?"

If we do care about satisfying challenge 2 in the `gamma > 0` situation, we'd want to round-to-nearest-sigma what comes out of `get_sigmas_karras()`. I happen to have made a torch snippet for running `argmin` on every element returned by `get_sigmas_karras()` simultaneously:

```python
sigmas = model_k_wrapped.sigmas[torch.argmin((sigmas.reshape(len(sigmas), 1).repeat(1, len(model_k_wrapped.sigmas)) - model_k_wrapped.sigmas).abs(), dim=1)]
```

But again, not sure of what the implications are for the 0 it returns.  
Anyway, maybe we can look at the outputs to decide. We'll try with keeping the 0 and without.

I tried to stress this to its limits by using as few steps as I could manage before it looked bad. All images are:  
- generated with Stable Diffusion, [commit 302e0b8](https://github.com/Birch-san/stable-diffusion/blob/302e0b8af44afa8923ef5d52042b853cc54ceba9/scripts/txt2img_fork.py) of [my fork](https://github.com/Birch-san/stable-diffusion)
- checkpoint [1.4 original](https://huggingface.co/CompVis/stable-diffusion-v-1-4-original)
- seed `68673924`
- `get_sigmas_karras()` noise schedule.  
- Heun, 7 steps.  
- prompt (forked from https://github.com/CompVis/stable-diffusion/issues/25#issuecomment-1229549499):  
  ```
  masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night
  ```

# Heun, 7 steps

## Excluding 0 from `get_sigmas_karras()`

The better-looking result was when I excluded the 0 returned by `get_sigmas_karras()`, in favour of ramping for 1 more step.

Recall that [SD's sigmas](https://gist.github.com/Birch-san/6cd1574e51871a5e2b88d59f0f3d4fd3) run from max = `14.6146` to min = `0.0292`.

Sigmas returned by `get_sigmas_karras()`:  
_`sample_heun` only iterates to n-1, so never touches the `0.0292`._

```
['14.6146', '7.9029', '4.0277', '1.9104', '0.8289', '0.3211', '0.1072', '0.0292']
```

### Time-step discretization enabled

Sigmas (up to n-1) after discretization:

```
['14.6146', '7.9216', '4.0300', '1.9103', '0.8299', '0.3213', '0.1072']
```

![00349 s68673924 n0 i0_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun7_kns_dcrt_nz](https://user-images.githubusercontent.com/6141784/187567193-82b04fbb-8ebc-4239-9ce2-69ff0a46edaf.png)

### Original k-diffusion behaviour (no discretization)

![00352 s68673924 n0 i0_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun7_kns_nz](https://user-images.githubusercontent.com/6141784/187567978-e4d0d67f-048e-4289-8418-b04f3a5a1b58.png)

Not much perceptible difference. The discrete one defines the far sleeve better, but the other subtle differences it's hard for me to say which is the better generation.

## Keeping 0 from `get_sigmas_karras()`

So the paper didn't mention this, but the result is terrible at low step counts if you actually implement the 0 as they describe. Maybe this is just a problem for discrete time models?

Sigmas returned by `get_sigmas_karras()`:  
_`sample_heun` only iterates to n-1, so never touches the 0._

```
['14.6146', '7.0944', '3.1686', '1.2741', '0.4469', '0.1303', '0.0292', '0.0000']
```

### Time-step discretization enabled

Sigmas (up to n-1) after discretization:

```
['14.6146', '7.0796', '3.1667', '1.2721', '0.4471', '0.1308', '0.0292']
```

![00350 s68673924 n0 i0_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun7_kns_dcrt](https://user-images.githubusercontent.com/6141784/187568535-90331ca2-adc1-4790-a85e-2814cf919ca1.png)

### Original k-diffusion behaviour (no discretization)

![00351 s68673924 n0 i0_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun7_kns](https://user-images.githubusercontent.com/6141784/187569837-e0158a17-1f6c-4466-a10c-c1ed8bcb49d0.png)

Slightly more perceptible difference. The discrete one did better on the eyes and has slightly more clothing definition.

# Conclusion

Removing the "concat 0" from `get_sigmas_karras()` seems to be hugely beneficial for small numbers of steps. This is not backed up by the literature. The reason I tried this was due to a misunderstanding. I saw that if I discretized the whole schedule, I'd end up with a repeated uargmin (`… 0.0292, 0.0292]`). I removed the concat 0 to ensure I didn't end up producing duplicates. I didn't realize though that the sampler stops at n-1 so repeats aren't actually a problem. But it seems that for a different reason, the results are far better.

Discretization of time-steps doesn't have the _dramatic_ impact I was hoping for, but is probably still a sensible thing to do on the basis that the paper recommended it.

# Heun, 50 steps, excluding 0

Let's do one more example, to 50 steps

### Time-step discretization enabled

![grid-0194 s68673924_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun50_kns_dcrt_nz](https://user-images.githubusercontent.com/6141784/187571687-1881b1ad-ad3a-46d9-9228-5c59f4331d19.png)

### Original k-diffusion behaviour (no discretization)

![grid-0195 s68673924_masterpiece character portrait of a girl, yukata, full resolution, 4k, artgerm, wlop, sarrailh, kuvshinov, global illumination, vaporwave, neon night_heun50_kns_nz](https://user-images.githubusercontent.com/6141784/187571716-592d6a4c-b70c-4772-8bd0-04ee472a6a8d.png)

Discretization seems to be more noticeable over 50 steps. The discretized image seems to have sharper hair and clothing, and highlights are brighter. Not sure I could say which is "better" though.

It's hard to compare images scrolling on GitHub; personally I flicked between these using QuickLook in the Finder.  
If you know a better way to evaluate whether this is an improvement: I'm all ears! 👂 