### PR TITLE
Allow installing via pip install -e <repo link> - Adds a setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ torchdiffeq
 torchvision
 tqdm
 wandb
-git+https://github.com/openai/CLIP
+git+https://github.com/openai/CLIP#egg=clip

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='k-diffusion',
+    version='0.0.1',
+    description='Karras et al. (2022) diffusion models for PyTorch',
+    packages=find_packages(),
+    install_requires=[
+        'accelerate',
+        'clean-fid',
+        'einops',
+        'jsonmerge',
+        'kornia',
+        'Pillow',
+        'resize-right',
+        'scikit-image',
+        'scipy',
+        'torch',
+        'torchdiffeq',
+        'torchvision',
+        'tqdm',
+        'wandb',
+    ],
+)


### PR DESCRIPTION
Hi, thanks for the excellent library! :)

Installing this repo using `pip install -e git+https://github.com/crowsonkb/k-diffusion#egg=k_diffusion` results in a `FileNotFoundError` since it looks for a `setup.py`.

I was able to use https://github.com/hlky/k-diffusion-sd to install it this way, but it lags behind a bit. I was wondering if you'd be open to accepting this  `setup.py` into the main repo (sourced from the hlky repo). This allows other users to use the latest k-diffusion library, without the error during installation.

Thanks