### PR TITLE
added support for non square Images

### DIFF
--- a/configs/config_32x64_small_butterflies.json
+++ b/configs/config_32x64_small_butterflies.json
@@ -1,0 +1,48 @@
+{
+    "model": {
+        "type": "image_v1",
+        "input_channels": 3,
+        "input_size": [32, 64],
+        "patch_size": 1,
+        "mapping_out": 256,
+        "scaling_comment": "increased the network depth due to larger image width",
+        "depths": [2, 2, 4, 4],
+        "channels": [128, 256, 256, 512],
+        "self_attn_depths": [false, false, true, true],
+        "has_variance": true,
+        "dropout_rate": 0.05,
+        "augment_wrapper": true,
+        "augment_prob": 0.12,
+        "sigma_data": 0.5,
+        "sigma_min": 1e-2,
+        "sigma_max": 80,
+        "sigma_sample_density": {
+            "type": "lognormal",
+            "mean": -1.2,
+            "std": 1.2
+        }
+    },
+    "dataset": {
+        "type": "huggingface",
+        "location": "huggan/smithsonian_butterflies_subset",
+        "image_key": "image"
+    },
+    "optimizer": {
+        "type": "adamw",
+        "lr": 1e-4,
+        "betas": [0.95, 0.999],
+        "eps": 1e-6,
+        "weight_decay": 1e-3
+    },
+    "lr_sched": {
+        "type": "inverse",
+        "inv_gamma": 20000.0,
+        "power": 1.0,
+        "warmup": 0.99
+    },
+    "ema_sched": {
+        "type": "inverse",
+        "power": 0.6667,
+        "max_value": 0.9999
+    }
+}

--- a/train.py
+++ b/train.py
@@ -78,9 +78,8 @@ def main():
     sched_config = config['lr_sched']
     ema_sched_config = config['ema_sched']
 
-    # TODO: allow non-square input sizes
-    assert len(model_config['input_size']) == 2 and model_config['input_size'][0] == model_config['input_size'][1]
-    size = model_config['input_size']
+    # format for size is [height, width] or [width_and_height]
+    size = model_config['input_size'] if len(model_config['input_size']) == 2 else [model_config['input_size'], model_config['input_size']]
 
     ddp_kwargs = accelerate.DistributedDataParallelKwargs(find_unused_parameters=model_config['skip_stages'] > 0)
     accelerator = accelerate.Accelerator(kwargs_handlers=[ddp_kwargs], gradient_accumulation_steps=args.grad_accum_steps)
@@ -137,8 +136,8 @@ def main():
                                   max_value=ema_sched_config['max_value'])
 
     tf = transforms.Compose([
-        transforms.Resize(size[0], interpolation=transforms.InterpolationMode.LANCZOS),
-        transforms.CenterCrop(size[0]),
+        transforms.Resize(size, interpolation=transforms.InterpolationMode.LANCZOS),
+        transforms.CenterCrop(size),
         K.augmentation.KarrasAugmentationPipeline(model_config['augment_prob']),
     ])
 


### PR DESCRIPTION
Non-Square images work basically out of the box. I trained a model with the smithsonian_butterflies_subset with 32x64 pixels and compared it to 48x48 pixels to roughly have the same number of total pixels.

FID 48x48 was 50.2 after 10_000 steps with batchsize 16
![model_demo_00010000](https://user-images.githubusercontent.com/4047875/194011956-1ed797f4-3f28-4279-84ad-9c8a82041680.png)

FID 64x32 was 59.9 after 10_000 steps with batchsize 16
![model_demo_00010000](https://user-images.githubusercontent.com/4047875/194012035-69b98b92-3f43-4436-9f80-08dff7307f50.png)