### PR TITLE
remove `clean-fid`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 accelerate
-clean-fid
 clip-anytorch
 einops
 jsonmerge


### PR DESCRIPTION
The `clean-fid` library has an old version of `requests` pinned in its dependencies that's currently causing me some headaches.

I see a couple discussions related to replacing/reimplementing `clean-fid` (#7 and #8), and I don't see any imports related to it in the current code, so I was wondering if you'd be open to removing it from the requirements file for the next release. Feel free to close this if not; just thought I'd check.

Thanks!