### PR TITLE
Do not merge! Credits for DEIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ on all nodes.
 
 - k-diffusion models support progressive growing.
 
+- [DEIS](https://arxiv.org/abs/2204.13902), where DPM-Solver are equivelent to $\rho$-RK in DEIS with second order mid point solver and third order Kutta method. And [linear multistep](https://en.wikipedia.org/wiki/Linear_multistep_method#Adams–Bashforth_methods) with warming start, which is exactly $\rho$-AB in DEIS.
+
 - k-diffusion implements [DPM-Solver](https://arxiv.org/abs/2206.00927), which produces higher quality samples at the same number of function evalutions as Karras Algorithm 2, as well as supporting adaptive step size control. It also implements a [linear multistep](https://en.wikipedia.org/wiki/Linear_multistep_method#Adams–Bashforth_methods) sampler (comparable to [PLMS](https://arxiv.org/abs/2202.09778)).
 
 - k-diffusion supports [CLIP](https://openai.com/blog/clip/) guided sampling from unconditional diffusion models (see `sample_clip_guided.py`).


### PR DESCRIPTION
Hi Katherine, 

Thanks for your awesome work. I open the issue to ask for credits of [DEIS](https://arxiv.org/abs/2204.13902) sampler.  

1. We are actually the first public work that proposes the usage of the exponential integrator method for solving diffusion model ODE, several months easier than concurrent works DPM-solver and Tero's Elucidate work.

Concurrent DPM-Solver~(second order and third order) and Heun method in Elucidate work is in fact exponential RK method with specific underlying RK solvers, 
* DPM-Solver 2 -> second order mid point
* DPM-Solver 3 -> third order kutta method
* Heun -> Heun.

Despite different motivations, equation 18 is the key for DPM-Solver and Heun in Elucidate work. And two changes of variables $t <-> \rho$ and $x <->y$ are equivalent to "rescaling" in Elucidate work. And we can use [more RK solvers](https://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods) for eq-18. Empirical comparisons among several RK solvers are also included in DEIS.

![image](https://user-images.githubusercontent.com/28699575/198122035-28ff5705-92ae-4ce5-9ad5-957ff8cde2af.png)

2. Besides, applying linear multistep with non-uniform step-size and lower order warming started in the transformed ODE is first proposed in DEIS. see $\rho AB$-DEIS. 

I know it is a bot area, but it is frustrating to be "scooped" and lose credits for a young researcher. Can you consider modifying readme? 