### PR TITLE
Fixing "SeedSequence expects int or sequence of ints for entropy not N.0"

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -77,7 +77,7 @@ class BatchedBrownianTree:
         except TypeError:
             seed = [seed]
             self.batched = False
-        self.trees = [torchsde.BrownianTree(t0, w0, t1, entropy=s, **kwargs) for s in seed]
+        self.trees = [torchsde.BrownianTree(t0, w0, t1, entropy=int(s), **kwargs) for s in seed]
 
     @staticmethod
     def sort(a, b):


### PR DESCRIPTION
When Using the [AUTOMATIC1111 ](https://github.com/AUTOMATIC1111/stable-diffusion-webui) or [vladmandic/automatic](https://github.com/vladmandic/automatic) stable diffusion webui, the Sampler `DPM++ SDE` spits out an error when a seed `3106912320` is defined in the `Prompt Matrix` script:

`SeedSequence expects int or sequence of ints for entropy not 3106912320.0`

This issues was reported in:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7989

And the user `grumpyland` posted a quick and dirty fix for it. Since this also fixed my problem in vladmandic/automatic, i made an issue request:
https://github.com/vladmandic/automatic/issues/904

`vladmandic` recommended to create a Pull Request, so here is my commit to it.