### PR TITLE
Eliminate jsonmerge dependency

### DIFF
--- a/k_diffusion/config.py
+++ b/k_diffusion/config.py
@@ -3,9 +3,17 @@ import json
 import math
 import warnings
 
-from jsonmerge import merge
-
 from . import augmentation, layers, models, utils
+
+
+def merge_config(defaults, config):
+    result = {**defaults}
+    for key, value in config.items():
+        if isinstance(value, dict):
+            result[key] = merge_config(result.get(key, {}), value)
+        else:
+            result[key] = value
+    return result
 
 
 def load_config(file):
@@ -44,7 +52,7 @@ def load_config(file):
         },
     }
     config = json.load(file)
-    return merge(defaults, config)
+    return merge_config(defaults, config)
 
 
 def make_model(config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ accelerate
 clean-fid
 clip-anytorch
 einops
-jsonmerge
 kornia
 Pillow
 resize-right

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ install_requires =
     clean-fid
     clip-anytorch
     einops
-    jsonmerge
     kornia
     Pillow
     resize-right


### PR DESCRIPTION
A change for your consideration which removes the jsonmerge dependency.

The jsonmerge library depends on the Rust persistent data structures `rpds` library which can only be imported into a process once. This creates a problem if you have an application which uses multiple libraries that each use k-diffusion (like diffusers + stablecore for example) and results in `PyO3 modules may only be initialized once per interpreter process` exception on the second time k-diffusion gets imported. 

Since jsonmerge is only used to merge config settings with default settings, this change replaces it with a small equivalent `merge_config` function.