### PR TITLE
fix: local variable 'h' referenced before assignment

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -645,7 +645,7 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
                     x = x + 0.5 * (-h - eta_h).expm1().neg() * (1 / r) * (denoised - old_denoised)
 
             x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * eta_h).expm1().neg().sqrt() * s_noise
+            h_last = h
 
         old_denoised = denoised
-        h_last = h
     return x


### PR DESCRIPTION
When using the stable diffusion webui, some of the boundary conditions result in the following error:

```
Traceback (most recent call last):
  ...
  File "/data/app/stable-diffusion-webui/modules/processing.py", line 610, in process_images
    res = process_images_inner(p)
  File "/data/app/stable-diffusion-webui/modules/processing.py", line 728, in process_images_inner
    samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
  File "/data/app/stable-diffusion-webui/modules/processing.py", line 1058, in sample
    samples = self.sampler.sample_img2img(self, samples, noise, self.hr_c, self.hr_uc, steps=self.hr_second_pass_steps or self.steps, image_conditioning=image_conditioning)
  File "/data/app/stable-diffusion-webui/modules/sd_samplers_kdiffusion.py", line 356, in sample_img2img
    samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
  File "/data/app/stable-diffusion-webui/modules/sd_samplers_kdiffusion.py", line 257, in launch_sampling
    return func()
  File "/data/app/stable-diffusion-webui/modules/sd_samplers_kdiffusion.py", line 356, in <lambda>
    samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/data/app/stable-diffusion-webui/repositories/k-diffusion/k_diffusion/sampling.py", line 650, in sample_dpmpp_2m_sde
    h_last = h
UnboundLocalError: local variable 'h' referenced before assignment
```

It worked well after the fix and I think it was a clerical error.