### PR TITLE
Fixed  UnboundLocalError

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -646,9 +646,9 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
 
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * eta_h).expm1().neg().sqrt() * s_noise
-
+            h_last = h
+            
         old_denoised = denoised
-        h_last = h
     return x
 
 
@@ -696,7 +696,7 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
 
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * h * eta).expm1().neg().sqrt() * s_noise
-
+            h_1, h_2 = h, h_1
+            
         denoised_1, denoised_2 = denoised, denoised_1
-        h_1, h_2 = h, h_1
     return x


### PR DESCRIPTION
Fixed the UnboundLocalError in the sample_dpmpp_2m_sde and sample_dpmpp_3m_sde functions. 
```
File "/workspace/stable-diffusion-webui/modules/processing.py", line 867, in process_images_inner
  samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
File "/workspace/stable-diffusion-webui/modules/processing.py", line 1528, in sample
  samples = self.sampler.sample_img2img(self, self.init_latent, x, conditioning, unconditional_conditioning, image_conditioning=self.image_conditioning)
File "/workspace/stable-diffusion-webui/modules/sd_samplers_kdiffusion.py", line 188, in sample_img2img
  samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
File "/workspace/stable-diffusion-webui/modules/sd_samplers_common.py", line 261, in launch_sampling
  return func()
File "/workspace/stable-diffusion-webui/modules/sd_samplers_kdiffusion.py", line 188, in <lambda>
  samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
File "/workspace/stable-diffusion-webui/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
  return func(*args, **kwargs)
File "/workspace/stable-diffusion-webui/repositories/k-diffusion/k_diffusion/sampling.py", line 701, in sample_dpmpp_3m_sde
  h_1, h_2 = h, h_1
UnboundLocalError: local variable 'h' referenced before assignment
```

This seems to be a problem that has arised in history. #74 