### PR TITLE
[transformer v2] Load + evaluate FID for OpenAI guided-diffusion models

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  "configurations": [
+    {
+      "name": "Python: Oxford Flowers (shifted window)",
+      "type": "python",
+      "request": "launch",
+      "program": "train.py",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "subProcess": false,
+      "args": [
+        "--config", "configs/config_oxford_flowers_shifted_window.json",
+        "--out-root", "out",
+        "--output-to-subdir",
+        "--name", "flowers_demo_001",
+        "--evaluate-n", "0",
+        "--batch-size", "32",
+        "--sample-n", "36",
+        "--mixed-precision", "bf16",
+        "--demo-img-compress",
+        "--font", "./kdiff_trainer/font/DejaVuSansMono.ttf",
+      ],
+    },
+    {
+      "name": "Python: Compute FID OpenAI",
+      "type": "python",
+      "request": "launch",
+      "program": "train.py",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "args": [
+        "--config", "configs/config_guided_diffusion_imagenet.json",
+        "--resume-inference", "/nvme1/ml-weights/256x256_diffusion.pt",
+        "--evaluate-only",
+        "--evaluate-n", "4",
+        "--start-method", "fork"
+      ]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,6 @@
 {
   "configurations": [
     {
-      "name": "Python: Oxford Flowers (shifted window)",
-      "type": "python",
-      "request": "launch",
-      "program": "train.py",
-      "console": "integratedTerminal",
-      "justMyCode": true,
-      "subProcess": false,
-      "args": [
-        "--config", "configs/config_oxford_flowers_shifted_window.json",
-        "--out-root", "out",
-        "--output-to-subdir",
-        "--name", "flowers_demo_001",
-        "--evaluate-n", "0",
-        "--batch-size", "32",
-        "--sample-n", "36",
-        "--mixed-precision", "bf16",
-        "--demo-img-compress",
-        "--font", "./kdiff_trainer/font/DejaVuSansMono.ttf",
-      ],
-    },
-    {
       "name": "Python: Compute FID OpenAI",
       "type": "python",
       "request": "launch",

--- a/configs/config_guided_diffusion_imagenet.json
+++ b/configs/config_guided_diffusion_imagenet.json
@@ -1,0 +1,26 @@
+{
+  "model": {
+    "type": "guided_diffusion",
+    "config": {
+      "attention_resolutions": "32, 16, 8",
+      "class_cond": true,
+      "diffusion_steps": 1000,
+      "image_size": 256,
+      "learn_sigma": true,
+      "noise_schedule": "linear",
+      "num_channels": 256,
+      "num_head_channels": 64,
+      "num_res_blocks": 2,
+      "resblock_updown": true,
+      "use_fp16": true,
+      "use_scale_shift_norm": true
+    },
+    "input_channels": 3,
+    "input_size": [256, 256]
+  },
+  "dataset": {
+    "type": "imagefolder-class",
+    "location": "/nvme1/ml-data/ImageNet/train",
+    "num_classes": 1000
+  }
+}

--- a/k_diffusion/utils.py
+++ b/k_diffusion/utils.py
@@ -336,6 +336,11 @@ def rand_log_logistic(shape, loc=0., scale=1., min_value=0., max_value=float('in
     return u.logit().mul(scale).add(loc).exp().to(dtype)
 
 
+def rand_uniform(shape, min_value, max_value, device='cpu', dtype=torch.float32):
+    """Draws samples from a uniform distribution."""
+    return (stratified_with_settings(shape, device=device, dtype=dtype) * (max_value - min_value) + min_value)
+
+
 def rand_log_uniform(shape, min_value, max_value, device='cpu', dtype=torch.float32):
     """Draws samples from an log-uniform distribution."""
     min_value = math.log(min_value)

--- a/kdiff_trainer/load_diffusion_model.py
+++ b/kdiff_trainer/load_diffusion_model.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import torch
+import safetensors
+from typing import Literal, Dict, NamedTuple
+import k_diffusion as K
+
+from guided_diffusion import script_util
+from guided_diffusion.unet import UNetModel
+from guided_diffusion.respace import SpacedDiffusion
+
+class OpenAIVDenoiser(K.external.DiscreteVDDPMDenoiser):
+    """A wrapper for OpenAI v objective diffusion models."""
+
+    def __init__(
+        self, model, diffusion, quantize=False, has_learned_sigmas=True, device="cpu"
+    ):
+        alphas_cumprod = torch.tensor(
+            diffusion.alphas_cumprod, device=device, dtype=torch.float32
+        )
+        super().__init__(model, alphas_cumprod, quantize=quantize)
+        self.has_learned_sigmas = has_learned_sigmas
+
+    def get_v(self, *args, **kwargs):
+        model_output = self.inner_model(*args, **kwargs)
+        if self.has_learned_sigmas:
+            return model_output.chunk(2, dim=1)[0]
+        return model_output
+
+class ModelAndDiffusion(NamedTuple):
+    model: UNetModel
+    diffusion: SpacedDiffusion
+
+def construct_diffusion_model(config_overrides: Dict = {}) -> ModelAndDiffusion:
+    model_config = script_util.model_and_diffusion_defaults()
+    if config_overrides:
+        model_config.update(config_overrides)
+    model, diffusion = script_util.create_model_and_diffusion(**model_config)
+    return ModelAndDiffusion(model, diffusion)
+
+def load_diffusion_model(
+    model_path: str,
+    model: UNetModel,
+):
+    if Path(model_path).suffix == ".safetensors":
+        safetensors.torch.load_model(model, model_path)
+    else:
+        model.load_state_dict(torch.load(model_path, map_location="cpu"))
+    if model.dtype is torch.float16:
+        model.convert_to_fp16()
+
+def wrap_diffusion_model(
+    model: UNetModel,
+    diffusion: SpacedDiffusion,
+    device="cpu",
+    model_type: Literal['eps', 'v'] = "eps"
+):
+    if model_type == "eps":
+        return K.external.OpenAIDenoiser(model, diffusion, device=device)
+    elif model_type == "v":
+        return OpenAIVDenoiser(model, diffusion, device=device)
+    else:
+        raise ValueError(f"Unknown model type {model_type}")

--- a/requirements.oai.txt
+++ b/requirements.oai.txt
@@ -1,0 +1,1 @@
+guided-diffusion @ git+https://github.com/crowsonkb/guided-diffusion#egg=guided-diffusion

--- a/train.py
+++ b/train.py
@@ -382,7 +382,7 @@ def main():
             return cfg_model_fn
         return model
 
-    @torch.no_grad()
+    @torch.inference_mode() # note: inference_mode is lower-overhead than no_grad but disables forward-mode AD
     @K.utils.eval_mode(model_ema)
     def demo():
         if accelerator.is_main_process:
@@ -407,7 +407,7 @@ def main():
             if use_wandb:
                 wandb.log({'demo_grid': wandb.Image(filename)}, step=step)
 
-    @torch.no_grad()
+    @torch.inference_mode() # note: inference_mode is lower-overhead than no_grad but disables forward-mode AD
     @K.utils.eval_mode(model_ema)
     def evaluate():
         if not evaluate_enabled:


### PR DESCRIPTION
- loads OpenAI guided-diffusion UNet
- `--evaluate-only` no longer requires you to specify a (redundant) `--evaluate-every` option
- `--evaluate-only` now turns off a bit more stuff
  - avoids constructing trainable model (so you don't pay RAM price of a copy you don't use, and so you don't pay VRAM to have accelerator prepare it)
  - avoids constructing + accelerator-preparing optimizer and schedules
  - doesn't force you to define a config for optimizer/schedules (well, there are defaults for those but still)
- switched demo/evaluate from [`no_grad`](https://pytorch.org/docs/stable/generated/torch.no_grad.html#torch.no_grad) to [`inference_mode`](https://pytorch.org/docs/stable/generated/torch.inference_mode.html), which is even lower-overhead