### PR TITLE
fix "UnboundLocalError: local variable 'h' referenced before assignment"

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -662,7 +662,7 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
     s_in = x.new_ones([x.shape[0]])
 
     denoised_1, denoised_2 = None, None
-    h_1, h_2 = None, None
+    h_1, h_2, h = None, None, None
 
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)


### PR DESCRIPTION
     h_1, h_2 = h, h_1
 UnboundLocalError: local variable 'h' referenced before assignment