### PR TITLE
fix: DPM-Solver++(2m & 3M) SDE.

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -646,9 +646,8 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
 
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * eta_h).expm1().neg().sqrt() * s_noise
-
-        old_denoised = denoised
-        h_last = h
+            h_last = h
+            old_denoised = denoised
     return x
 
 
@@ -697,6 +696,6 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * h * eta).expm1().neg().sqrt() * s_noise
 
-        denoised_1, denoised_2 = denoised, denoised_1
-        h_1, h_2 = h, h_1
+            denoised_1, denoised_2 = denoised, denoised_1
+            h_1, h_2 = h, h_1
     return x


### PR DESCRIPTION
When using the stable diffusion webui with "DPM++ 3M SDE Karras", some of the boundary conditions result in the following error:

```
      File "/stable-diffusion-webui/repositories/k-diffusion/k_diffusion/sampling.py", line 700, in sample_dpmpp_3m_sde
        h_1, h_2 = h, h_1
    UnboundLocalError: local variable 'h' referenced before assignment
```

Checking the code, it seems that the indentation of the last part of `sample_dpmpp_2m_sde` and `sample_dpmpp_3m_sde` functions were wrong, and that's why h var was not defined in both samplers.