### PR TITLE
remove append_dims from to_d to allow sigmas on cpu

### DIFF
--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -45,7 +45,7 @@ def get_sigmas_vp(n, beta_d=19.9, beta_min=0.1, eps_s=1e-3, device='cpu'):
 
 def to_d(x, sigma, denoised):
     """Converts a denoiser output to a Karras ODE derivative."""
-    return (x - denoised) / utils.append_dims(sigma, x.ndim)
+    return (x - denoised) / sigma
 
 
 def get_ancestral_step(sigma_from, sigma_to, eta=1.):


### PR DESCRIPTION
This would close #108.

I changed the one operation that actually relies on sigmas being on the same device as the model samples and changed it so that it is a simple scalar multiplication.  As far as I know, this should work as long as we can assume that `sigmas` passed into the model is a 1d tensor.  Please let me know if this is a bad assumption!  The only way I could see it failing is if people regularly are passing in batched samples with differing per-batch-item sigmas.

With this, the samplers will allow CPU tensors as the input for sigmas, and won't block dispatch anymore.