### PR TITLE
Fix Denoiser crash when passing callable weighting function

### DIFF
--- a/k_diffusion/layers.py
+++ b/k_diffusion/layers.py
@@ -52,7 +52,7 @@ class Denoiser(nn.Module):
         self.scales = scales
         if callable(weighting):
             self.weighting = weighting
-        if weighting == 'karras':
+        elif weighting == 'karras':
             self.weighting = torch.ones_like
         elif weighting == 'soft-min-snr':
             self.weighting = self._weighting_soft_min_snr


### PR DESCRIPTION
## Summary

- The `Denoiser.__init__` method uses two independent `if` statements for the `weighting` parameter instead of a single `if/elif` chain. When a callable is passed, the first `if callable(weighting)` branch correctly assigns `self.weighting`, but execution falls through to the second `if weighting == 'karras'` block. Since the callable doesn't match any string comparison, it reaches the `else` branch and raises `ValueError(f'Unknown weighting type {weighting}')`.
- Fix: change the second `if` to `elif` so the entire block forms one `if/elif` chain, preventing the fall-through.

## Reproduction

```python
from k_diffusion.layers import Denoiser

custom_weight = lambda sigma: sigma ** 2
model = ...  # any inner model
# This raises ValueError despite callable weighting being explicitly supported:
denoiser = Denoiser(model, weighting=custom_weight)
```

## Test plan

- [x] Verified that passing a callable `weighting` no longer raises `ValueError`
- [x] Verified that string values (`'karras'`, `'soft-min-snr'`, `'snr'`) still work correctly
- [x] Verified that invalid strings still raise `ValueError` as expected